### PR TITLE
Use a github_username custom field

### DIFF
--- a/services/gumroad-github-access/src/server.ts
+++ b/services/gumroad-github-access/src/server.ts
@@ -44,6 +44,9 @@ const convertFormPayloadToJson = (
   email: formValues.get("email") || "",
   refunded: formValues.get("refunded") === "true",
   seller_id: formValues.get("seller_id") || "",
+  custom_fields: {
+    github_username: formValues.get("github_username"),
+  },
 });
 
 /**
@@ -131,9 +134,15 @@ const processWebhook = async ({
         );
       }
 
-      const gitHubUsername = await findGitHubUserByEmail(webhookPayload.email);
-      console.log("GitHub username:", gitHubUsername);
+      let gitHubUsername = webhookPayload.custom_fields.github_username;
+      if (!gitHubUsername) {
+        console.log(
+          "GitHub username custom field not available. Searching on GitHub..."
+        );
+        gitHubUsername = await findGitHubUserByEmail(webhookPayload.email);
+      }
 
+      console.log("GitHub username:", gitHubUsername);
       if (!gitHubUsername) {
         throw new Error(
           `GitHub user for email "${webhookPayload.email}" could not be found.`


### PR DESCRIPTION
People who use the same email address on Gumroad and GitHub, but don't have the email address listed as public, could not be found via the GitHub API.

I added a custom field called `github_username` to the Gumroad checkout form. If that field is available, use it and don't call the GitHub search API.